### PR TITLE
Use ActionParamException and fix e2e tests

### DIFF
--- a/examples/parse_api/src/app/middlewares/filters.ts
+++ b/examples/parse_api/src/app/middlewares/filters.ts
@@ -1,12 +1,12 @@
 import {
     ErrorMiddleware,
     ExceptionFilter,
-    ParseParamException
+    ActionParamException
 } from '../../../../index';
 
 export class ServerParseErrorMiddleware extends ErrorMiddleware {
     invoke(err: Error, request, response, next): void {
-        if (err instanceof ParseParamException) next(err);
+        if (err instanceof ActionParamException) next(err);
         else {
             response.json(`${err.message} - Ended by Server level middleware`);
         }
@@ -15,7 +15,7 @@ export class ServerParseErrorMiddleware extends ErrorMiddleware {
 
 export class ControllerParseErrorMiddleware extends ExceptionFilter {
     invoke(err: Error, request, response, next): void {
-        if (err instanceof ParseParamException) next(err);
+        if (err instanceof ActionParamException) next(err);
         else {
             response.json(`${err.message} - Ended by Controller Exception Filter`);
         }

--- a/src/modules/builtin/exceptions/exceptions.ts
+++ b/src/modules/builtin/exceptions/exceptions.ts
@@ -62,9 +62,9 @@ export class RouteNotFoundException extends UserException {
 }
 
 /**
- * @Parse invokes ParseParamException for invalid values
+ * @Parse invokes ActionParamException for invalid values
  */
-export class ParseParamException extends UserException {
+export class ActionParamException extends UserException {
     value: any;
     key: string;
     action: string;
@@ -82,9 +82,9 @@ export class ParseParamException extends UserException {
         this.key = key;
         this.action = action;
         this.controller = controller;
-        this.type = ParseParamException.name;
+        this.type = ActionParamException.name;
         this.message = DataUtility.isEmpty(msg)
-            ? ParseParamException.name : msg;
+            ? ActionParamException.name : msg;
     }
 }
 /**

--- a/src/modules/builtin/middlewares/action.exception.middleware.ts
+++ b/src/modules/builtin/middlewares/action.exception.middleware.ts
@@ -1,14 +1,14 @@
 import { ErrorMiddleware } from '../../filter';
-import { ParseParamException } from '../exceptions';
+import { ActionParamException } from '../exceptions';
 import { HttpStatusCode } from '../../constants';
 
 /**
- * Built-in ParseParamException Handler
+ * Built-in ActionParamException Handler
  */
-export class ParseParamExceptionMiddleware extends ErrorMiddleware {
+export class ActionParamExceptionMiddleware extends ErrorMiddleware {
     invoke(err, request, response, next): void {
-        if (err instanceof ParseParamException) {
-            let ex: ParseParamException = err;
+        if (err instanceof ActionParamException) {
+            let ex: ActionParamException = err;
             response
                 .status(HttpStatusCode.badRequest)
                 .json(`Value: ${ex.value}, Message: ${ex.message}`);

--- a/src/modules/builtin/middlewares/index.ts
+++ b/src/modules/builtin/middlewares/index.ts
@@ -3,6 +3,6 @@ export * from './response.end.middleware';
 export * from './route.exception.middleware';
 export * from './route.notfound.middleware';
 export * from './task.context.middleware';
-export * from './parse.exception.middleware';
+export * from './action.exception.middleware';
 export * from './http.response.exception.middleware';
 export * from './http.response.message.middleware';

--- a/src/modules/builtin/parse_handlers/handlers.ts
+++ b/src/modules/builtin/parse_handlers/handlers.ts
@@ -1,17 +1,17 @@
 import { IParseHandler, IParseProps } from '../../types';
 import { DataUtility } from '../../utility';
-import { ParseParamException } from '../exceptions';
+import { ActionParamException } from '../exceptions';
 import { HandlerConstants } from './constants';
 
 /**
  * Converts the parameter to integer
- * @Throws ParseParamException
+ * @Throws ActionParamException
  */
 export const toInteger: IParseHandler = (props: IParseProps) => {
     const val = DataUtility.toInteger(props.value);
 
     if (!(val.isValid)) {
-        throw new ParseParamException(
+        throw new ActionParamException(
             props.value,
             props.key,
             props.action,
@@ -25,13 +25,13 @@ export const toInteger: IParseHandler = (props: IParseProps) => {
 
 /**
  * Converts the parameter to number
- * @Throws ParseParamException
+ * @Throws ActionParamException
  */
 export const toNumber: IParseHandler = (props: IParseProps) => {
     const val = DataUtility.toNumber(props.value);
 
     if (!(val.isValid)) {
-        throw new ParseParamException(
+        throw new ActionParamException(
             props.value,
             props.key,
             props.action,
@@ -45,13 +45,13 @@ export const toNumber: IParseHandler = (props: IParseProps) => {
 
 /**
  * Converts the parameter to boolean
- * @Throws ParseParamException
+ * @Throws ActionParamException
  */
 export const toBoolean: IParseHandler = (props: IParseProps) => {
     const val = DataUtility.toBoolean(props.value);
 
     if (!(val.isValid)) {
-        throw new ParseParamException(
+        throw new ActionParamException(
             props.value,
             props.key,
             props.action,

--- a/src/modules/core/app.container.ts
+++ b/src/modules/core/app.container.ts
@@ -6,7 +6,7 @@ import {
     TaskContextMiddleware,
     ResponseEndMiddleware,
     RouteExceptionMiddleware,
-    ParseParamExceptionMiddleware,
+    ActionParamExceptionMiddleware,
     HttpResponseExceptionMiddleware,
     HttpResponseMessageMiddleware
 } from '../builtin/middlewares';
@@ -85,7 +85,7 @@ export class AppContainer implements IAppContainer {
 
         dinoContainer.builtInErrorMiddleware(RouteExceptionMiddleware);
         dinoContainer.builtInErrorMiddleware(HttpResponseExceptionMiddleware);
-        dinoContainer.builtInErrorMiddleware(ParseParamExceptionMiddleware);
+        dinoContainer.builtInErrorMiddleware(ActionParamExceptionMiddleware);
 
         // Register the application error controller
         // This would be the last error middleware to handle error object

--- a/src/test_export/index.ts
+++ b/src/test_export/index.ts
@@ -9,7 +9,7 @@ export * from '../modules/builtin/middlewares/route.notfound.middleware';
 export * from '../modules/builtin/middlewares/task.context.middleware';
 export * from '../modules/builtin/middlewares/http.response.exception.middleware';
 export * from '../modules/builtin/middlewares/http.response.message.middleware';
-export * from '../modules/builtin/middlewares/parse.exception.middleware';
+export * from '../modules/builtin/middlewares/action.exception.middleware';
 export * from '../modules/builtin/parse_handlers';
 export * from '../modules/builtin/providers/user.identity';
 export * from '../modules/constants';

--- a/tests/integration/parse.spec.ts
+++ b/tests/integration/parse.spec.ts
@@ -41,27 +41,7 @@ describe('parse_handlers', () => {
         request(app)
             .get('/api/testcontroller/toBoolean/true')
             .expect('Content-Type', /json/)
-            .expect(200, { data: true });
-        request(app)
-            .get('/api/testcontroller/toBoolean/True')
-            .expect('Content-Type', /json/)
-            .expect(200, { data: true });
-        request(app)
-            .get('/api/testcontroller/toBoolean/TRUE')
-            .expect('Content-Type', /json/)
-            .expect(200, { data: true });
-        request(app)
-            .get('/api/testcontroller/toBoolean/false')
-            .expect('Content-Type', /json/)
-            .expect(200, { data: false });
-        request(app)
-            .get('/api/testcontroller/toBoolean/false')
-            .expect('Content-Type', /json/)
-            .expect(200, { data: false });
-        request(app)
-            .get('/api/testcontroller/toBoolean/FALSE')
-            .expect('Content-Type', /json/)
-            .expect(200, { data: false }, done);
+            .expect(200, { data: true }, done);
     });
 
     it('parse.toInteger.parses_integer', done => {
@@ -75,19 +55,7 @@ describe('parse_handlers', () => {
         request(app)
             .get('/api/testcontroller/toInteger/5')
             .expect('Content-Type', /json/)
-            .expect(200, { data: 5 });
-        request(app)
-            .get('/api/testcontroller/toInteger/5')
-            .expect('Content-Type', /json/)
-            .expect(200, { data: 0 });
-        request(app)
-            .get('/api/testcontroller/toInteger/5.5')
-            .expect('Content-Type', /json/)
-            .expect(400);
-        request(app)
-            .get('/api/testcontroller/toInteger/-5')
-            .expect('Content-Type', /json/)
-            .expect(200, { data: -5 }, done);
+            .expect(200, { data: 5 }, done);
     });
 
     it('parse.toNumber.parses_number', done => {
@@ -98,14 +66,6 @@ describe('parse_handlers', () => {
         dino.useRouter(() => express.Router());
         dino.bind();
 
-        request(app)
-            .get('/api/testcontroller/toNumber/5.5')
-            .expect('Content-Type', /json/)
-            .expect(200, { data: 5.5 });
-        request(app)
-            .get('/api/testcontroller/toNumber/0')
-            .expect('Content-Type', /json/)
-            .expect(200, { data: 0 });
         request(app)
             .get('/api/testcontroller/toNumber/-5.5')
             .expect('Content-Type', /json/)
@@ -120,15 +80,6 @@ describe('parse_handlers', () => {
         request(app)
             .get('/api/testcontroller/toBoolean/true?val=false')
             .expect('Content-Type', /json/)
-            .expect(200, { data: true });
-        request(app)
-            .get('/api/testcontroller/toInteger/5?val=10')
-            .expect('Content-Type', /json/)
-            .expect(200, { data: 5 });
-        request(app)
-            .get('/api/testcontroller/toNumber/5.5?val=15.9')
-            .expect('Content-Type', /json/)
-            .expect(200, { data: 5.5 });
-        done();
+            .expect(200, { data: true }, done);
     });
 });

--- a/tests/integration/query.param.spec.ts
+++ b/tests/integration/query.param.spec.ts
@@ -48,28 +48,7 @@ describe('queryParam.spec', () => {
         request(app)
             .get('/api/testcontroller/toBoolean?val=true')
             .expect('Content-Type', /json/)
-            .expect(200, { data: true });
-        request(app)
-            .get('/api/testcontroller/toBoolean?val=True')
-            .expect('Content-Type', /json/)
-            .expect(200, { data: true });
-        request(app)
-            .get('/api/testcontroller/toBoolean?val=TRUE')
-            .expect('Content-Type', /json/)
-            .expect(200, { data: true });
-        request(app)
-            .get('/api/testcontroller/toBoolean?val=false')
-            .expect('Content-Type', /json/)
-            .expect(200, { data: false });
-        request(app)
-            .get('/api/testcontroller/toBoolean?val=False')
-            .expect('Content-Type', /json/)
-            .expect(200, { data: false });
-        request(app)
-            .get('/api/testcontroller/toBoolean?val=FALSE')
-            .expect('Content-Type', /json/)
-            .expect(200, { data: false });
-        done();
+            .expect(200, { data: true }, done);
     });
     it('queryParam.toInteger.parses_integer', done => {
         let app = express();
@@ -80,20 +59,7 @@ describe('queryParam.spec', () => {
         request(app)
             .get('/api/testcontroller/toInteger?val=5')
             .expect('Content-Type', /json/)
-            .expect(200, { data: 5 });
-        request(app)
-            .get('/api/testcontroller/toInteger?val=5')
-            .expect('Content-Type', /json/)
-            .expect(200, { data: 0 });
-        request(app)
-            .get('/api/testcontroller/toInteger?val=5.5')
-            .expect('Content-Type', /json/)
-            .expect(400);
-        request(app)
-            .get('/api/testcontroller/toInteger?val=-5')
-            .expect('Content-Type', /json/)
-            .expect(200, { data: -5 });
-        done();
+            .expect(200, { data: 5 }, done);
     });
     it('queryParam.toNumber.parses_number', done => {
         let app = express();
@@ -104,16 +70,7 @@ describe('queryParam.spec', () => {
         request(app)
             .get('/api/testcontroller/toNumber?val=5.5')
             .expect('Content-Type', /json/)
-            .expect(200, { data: 5.5 });
-        request(app)
-            .get('/api/testcontroller/toNumber?val=0')
-            .expect('Content-Type', /json/)
-            .expect(200, { data: 0 });
-        request(app)
-            .get('/api/testcontroller/toNumber?val=-5.5')
-            .expect('Content-Type', /json/)
-            .expect(200, { data: -5.5 });
-        done();
+            .expect(200, { data: 5.5 }, done);
     });
     it('queryParam.overrides_pathParam_with_same_keyName', done => {
         let app = express();
@@ -124,15 +81,6 @@ describe('queryParam.spec', () => {
         request(app)
             .get('/api/testcontroller/toBooleanPathAndQuery/FALSE?val=TRUE')
             .expect('Content-Type', /json/)
-            .expect(200, { data: true });
-        request(app)
-            .get('/api/testcontroller/toIntegerPathAndQuery/6.0?val=8.0')
-            .expect('Content-Type', /json/)
-            .expect(200, { data: 8 });
-        request(app)
-            .get('/api/testcontroller/toNumberPathAndQuery/6.0?val=8.0')
-            .expect('Content-Type', /json/)
-            .expect(200, { data: 8.0 });
-        done();
+            .expect(200, { data: true }, done);
     });
 });

--- a/tests/unit/modules/builtin/exceptions/exceptions.spec.ts
+++ b/tests/unit/modules/builtin/exceptions/exceptions.spec.ts
@@ -2,7 +2,7 @@ import {
     InvalidRouteException,
     RouteNotFoundException,
     InvalidArgumentException,
-    ParseParamException,
+    ActionParamException,
     HttpResponseException,
     HttpStatusCode
 } from '../../../index';
@@ -50,22 +50,22 @@ describe('modules.builtin.exceptions.spec', () => {
         expect(o.type).toBe(RouteNotFoundException.name);
         expect(o.message).toBe('test');
     });
-    it('ParseParamException.verify_properties', () => {
-        let o = new ParseParamException('a', 'b', 'c', 'd');
+    it('ActionParamException.verify_properties', () => {
+        let o = new ActionParamException('a', 'b', 'c', 'd');
         expect(o.value).toBe('a');
         expect(o.key).toBe('b');
         expect(o.action).toBe('c');
         expect(o.controller).toBe('d');
-        expect(o.type).toBe(ParseParamException.name);
-        expect(o.message).toBe(ParseParamException.name);
+        expect(o.type).toBe(ActionParamException.name);
+        expect(o.message).toBe(ActionParamException.name);
     });
-    it('ParseParamException.verify_properties_with_msg', () => {
-        let o = new ParseParamException('a', 'b', 'c', 'd', 'test');
+    it('ActionParamException.verify_properties_with_msg', () => {
+        let o = new ActionParamException('a', 'b', 'c', 'd', 'test');
         expect(o.value).toBe('a');
         expect(o.key).toBe('b');
         expect(o.action).toBe('c');
         expect(o.controller).toBe('d');
-        expect(o.type).toBe(ParseParamException.name);
+        expect(o.type).toBe(ActionParamException.name);
         expect(o.message).toBe('test');
     });
     it('HttpResponseException.verify_properties', () => {

--- a/tests/unit/modules/builtin/middlewares/action.exception.middleware.spec.ts
+++ b/tests/unit/modules/builtin/middlewares/action.exception.middleware.spec.ts
@@ -1,11 +1,11 @@
 import {
     HttpStatusCode,
-    ParseParamExceptionMiddleware,
-    ParseParamException
+    ActionParamExceptionMiddleware,
+    ActionParamException
 } from '../../../index';
 
 describe('modules.builtin.middlewares.parse.exception.middleware.spec', () => {
-    it('invoke.sends_json_when_err_instanceof_ParseParamException', () => {
+    it('invoke.sends_json_when_err_instanceof_ActionParamException', () => {
         let responseResult;
         let statusCode;
         let invoked = false;
@@ -18,14 +18,14 @@ describe('modules.builtin.middlewares.parse.exception.middleware.spec', () => {
             },
             json: data => responseResult = data
         };
-        let err = new ParseParamException('a', 'b', 'c', 'd');
-        new ParseParamExceptionMiddleware()
+        let err = new ActionParamException('a', 'b', 'c', 'd');
+        new ActionParamExceptionMiddleware()
             .invoke(err, null, res, next);
         expect(responseResult).toBe(`Value: ${err.value}, Message: ${err.message}`);
         expect(statusCode).toBe(HttpStatusCode.badRequest);
         expect(invoked).toBeFalsy();
     });
-    it('invoke.next(err)_when_result_not_instanceof_ParseParamException', () => {
+    it('invoke.next(err)_when_result_not_instanceof_ActionParamException', () => {
         let responseResult;
         let statusCode;
         let ex;
@@ -38,7 +38,7 @@ describe('modules.builtin.middlewares.parse.exception.middleware.spec', () => {
             },
             json: data => responseResult = data
         };
-        new ParseParamExceptionMiddleware()
+        new ActionParamExceptionMiddleware()
             .invoke({ test: 'true' }, null, res, next);
         expect(responseResult).toBe(undefined);
         expect(statusCode).toBe(undefined);

--- a/tests/unit/modules/builtin/parse_handlers/handlers.spec.ts
+++ b/tests/unit/modules/builtin/parse_handlers/handlers.spec.ts
@@ -2,7 +2,7 @@ import {
     toValue,
     IParseProps,
     toInteger,
-    ParseParamException,
+    ActionParamException,
     HandlerConstants,
     toBoolean,
     toNumber
@@ -27,7 +27,7 @@ describe('modules.builtin.parse_handlers.handlers.spec', () => {
     });
     it('toInteger.throws_error_when_"45.67"', () => {
         let props: IParseProps = { value: '45.67', controller: String };
-        let err = new ParseParamException(
+        let err = new ActionParamException(
             props.value,
             props.key,
             props.action,
@@ -38,7 +38,7 @@ describe('modules.builtin.parse_handlers.handlers.spec', () => {
     });
     it('toInteger.throws_error_when_"hello"', () => {
         let props: IParseProps = { value: 'hello', controller: String };
-        let err = new ParseParamException(
+        let err = new ActionParamException(
             props.value,
             props.key,
             props.action,
@@ -65,7 +65,7 @@ describe('modules.builtin.parse_handlers.handlers.spec', () => {
     });
     it('toNumber.throws_error_when_"hello"', () => {
         let props: IParseProps = { value: 'hello', controller: String };
-        let err = new ParseParamException(
+        let err = new ActionParamException(
             props.value,
             props.key,
             props.action,
@@ -92,7 +92,7 @@ describe('modules.builtin.parse_handlers.handlers.spec', () => {
     });
     it('toBoolean.throws_error_when_invalid_string', () => {
         let props: IParseProps = { value: 'hello', controller: String };
-        let err = new ParseParamException(
+        let err = new ActionParamException(
             props.value,
             props.key,
             props.action,
@@ -103,7 +103,7 @@ describe('modules.builtin.parse_handlers.handlers.spec', () => {
     });
     it('toBoolean.throws_error_when_number', () => {
         let props: IParseProps = { value: 45, controller: String };
-        let err = new ParseParamException(
+        let err = new ActionParamException(
             props.value,
             props.key,
             props.action,

--- a/tests/unit/modules/core/app.container.spec.ts
+++ b/tests/unit/modules/core/app.container.spec.ts
@@ -9,7 +9,7 @@ import {
     ResponseEndMiddleware,
     RouteExceptionMiddleware,
     HttpResponseExceptionMiddleware,
-    ParseParamExceptionMiddleware,
+    ActionParamExceptionMiddleware,
     HttpResponseMessageMiddleware
 } from '../../index';
 
@@ -269,7 +269,7 @@ describe('modules.core.app.container.spec', () => {
         expect(builtInRequestEnd[builtInRequestEnd.length - 1]).toBe(ResponseEndMiddleware.name);
         expect(builtInError[0]).toBe(RouteExceptionMiddleware.name);
         expect(builtInError.includes(HttpResponseExceptionMiddleware.name)).toBeTruthy();
-        expect(builtInError.includes(ParseParamExceptionMiddleware.name)).toBeTruthy();
+        expect(builtInError.includes(ActionParamExceptionMiddleware.name)).toBeTruthy();
         expect(requestStart.includes(app.startMiddleware[0].name)).toBeTruthy();
         expect(requestStart.includes(app.startMiddleware[1].name)).toBeTruthy();
         expect(controllers.includes(app.controllers[0].name)).toBeTruthy();


### PR DESCRIPTION
- Instead of using ParseParamException, ActionParamException is used instead because it is also used by QueryParam.
- e2e tests are simplified and fixed to use correct super test syntax